### PR TITLE
Adapt color to the header when scrolling

### DIFF
--- a/assets/stylesheets/tagging.scss
+++ b/assets/stylesheets/tagging.scss
@@ -58,6 +58,8 @@
   line-height: 1.4em !important;
 }
 
+header .discourse-tag {color: scale-color($header_primary, $lightness: 50%) !important; }
+
 .list-tags {
   display: inline;
   margin-left: 4px;


### PR DESCRIPTION
When scrolling, the `title-wrapper` container goes into the header so the color of the tags should be adapted in order to preserve readability in the case where the background is dark.

Example of the current issue: ![screenshot 2015-04-16 20-21-16](https://cloud.githubusercontent.com/assets/6014433/7188208/5eac2f70-e476-11e4-8ee2-fe02069204e0.png)
