### PR TITLE
Set the width of tags input to 100%.

### DIFF
--- a/assets/stylesheets/tagging.scss
+++ b/assets/stylesheets/tagging.scss
@@ -67,7 +67,7 @@ header .discourse-tag {color: scale-color($header_primary, $lightness: 50%) !imp
 }
 
 .tag-chooser {
-  width: 500px;
+  width: 100%;
   margin: 5px 0;
 }
 


### PR DESCRIPTION
Fixes: https://meta.discourse.org/t/saved-hidden-behind-tags-box/29576/6

In conjuction with: https://github.com/discourse/discourse/pull/3561

![](https://lh3.googleusercontent.com/lURX-v1CKSiCYb8SxJ3vCP37nbnH4z5WfB1Kqkp_IHw=w1156-h499-no)
![](https://lh3.googleusercontent.com/7UqUHQpKel88qSZHfDnOC8ZC6XUBif5mwE_5oENeiaY=w1156-h499-no)
